### PR TITLE
Add update and delete endpoints for Todo items

### DIFF
--- a/Todo.Api/Controllers/TodoController.cs
+++ b/Todo.Api/Controllers/TodoController.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Client;
 using Todo.Api.Models;
 using Todo.Api.Services;
 
@@ -9,10 +11,12 @@ namespace Todo.Api.Controllers;
 public class TodoController : ControllerBase
 {
     private readonly TodoService _todoService;
+    private readonly DbContext _dbContext; // Add DbContext as a dependency
 
-    public TodoController(TodoService todoService)
+    public TodoController(TodoService todoService, DbContext dbContext)
     {
         _todoService = todoService;
+        _dbContext = dbContext; // Initialize DbContext
     }
 
     // GET: /todo
@@ -31,4 +35,54 @@ public class TodoController : ControllerBase
         return CreatedAtAction(nameof(GetAll), new { id = TodoItem.Id }, TodoItem);
     }
 
+    // GET: /todo/{id}
+    [HttpGet]
+    [Route("{id}")]
+    public async Task<IActionResult> GetTaskById(Guid id)
+    {
+        var task = await _dbContext.Set<TodoItem>().FindAsync(id);
+        if (task == null)
+        {
+            return NotFound();
+        }
+        return Ok(task);
+    }
+
+    // PUT: /todo/{id}
+    [HttpPut]
+    [Route("{id:guid}")]
+    public async Task<IActionResult> UpdateTask(Guid id, UpdateTaskDto updateTaskDto)
+    {
+        var task = await _dbContext.Set<TodoItem>().FindAsync(id);
+        if (task == null)
+        {
+            return NotFound();
+        }
+
+        task.Title = updateTaskDto.Title;
+        task.Description = updateTaskDto.Description;
+        task.DateUpdated = DateTime.UtcNow;
+
+        _dbContext.Update(task);
+        await _dbContext.SaveChangesAsync();
+
+        return Ok();
+    }
+
+    // DELETE: /todo/{id}
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteTodo(Guid id)
+    {
+        var task = await _dbContext.Set<TodoItem>().FindAsync(id);
+        if (task == null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.Set<TodoItem>().Remove(task);
+        await _dbContext.SaveChangesAsync();
+
+        return Ok();
+    }
 }
+   

--- a/Todo.Api/Controllers/TodoController.cs
+++ b/Todo.Api/Controllers/TodoController.cs
@@ -48,7 +48,7 @@ public class TodoController : ControllerBase
         return Ok(task);
     }
 
-    // PUT: /todo/{id}
+    // Update: /todo/{id}
     [HttpPut]
     [Route("{id:guid}")]
     public async Task<IActionResult> UpdateTask(Guid id, UpdateTaskDto updateTaskDto)

--- a/Todo.Api/Models/UpdateTaskDto.cs
+++ b/Todo.Api/Models/UpdateTaskDto.cs
@@ -7,5 +7,6 @@
         public string? Description { get; set; }
         public DateTime DateCreated { get; set; } = DateTime.UtcNow;
         public DateTime? DateUpdated { get; set; }
+        public bool IsCompleted { get; internal set; }
     }
 }

--- a/Todo.Api/Models/UpdateTaskDto.cs
+++ b/Todo.Api/Models/UpdateTaskDto.cs
@@ -1,0 +1,11 @@
+﻿namespace Todo.Api.Models
+{
+    public class UpdateTaskDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime? DateUpdated { get; set; }
+    }
+}

--- a/Todo.Api/appsettings.json
+++ b/Todo.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": ""
+    "DefaultConnection": "Data Source=plesk6700.is.cc;Initial Catalog=CogniSchole_TodoApp;User Id=cognischol_todo_user;Password=?DV48z$iGzt4mbbl;Integrated Security=false;MultipleActiveResultSets=True;TrustServerCertificate=True;"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
This PR adds two new endpoints to the Todo API:
- PUT /api/todos/{id} to update a Todo item
- DELETE /api/todos/{id} to delete a Todo item

Also includes null checks and proper status code responses.